### PR TITLE
Redesign intro, menu, and task interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,18 @@
 <body class="light">
   <div id="logo-screen" class="center">
     <img src="logo.png" alt="Logo" id="logo" />
+    <p id="logo-text" class="hidden">Construa a si mesmo</p>
   </div>
 
   <div id="question-screen" class="hidden center">
     <h1 id="question-title"></h1>
+    <img id="aspect-image" class="aspect-image" alt="Aspecto" />
     <div class="progress-container">
       <div id="progress-bar"></div>
     </div>
+    <div id="slider-feedback" class="slider-feedback"></div>
     <div class="slider-container">
-      <input type="range" min="1" max="10" value="5" id="slider" />
-      <span id="slider-value">5</span>
+      <input type="range" min="0" max="100" value="50" id="slider" />
     </div>
     <button id="next-btn">Próximo</button>
   </div>
@@ -40,7 +42,7 @@
       </div>
     </div>
     <nav id="menu-dropdown" class="dropdown hidden">
-      <a data-page="constitution">Constituição</a>
+      <a data-page="menu">Menu</a>
       <a data-page="tasks">Tarefas</a>
       <a data-page="laws">Leis</a>
       <a data-page="stats">Estatísticas</a>
@@ -50,9 +52,15 @@
   </header>
 
   <main id="main-content" class="hidden">
-    <section id="constitution" class="page active">
-      <h1>Constituição</h1>
-      <div id="constitution-content"></div>
+    <section id="menu" class="page active">
+      <div class="menu-grid">
+        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /><span>Histórico</span></div>
+        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /><span>Mindset</span></div>
+        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /><span>Leis</span></div>
+        <div class="menu-item" data-page="constitution"><img src="constituicao.png" alt="Constituição" /><span>Constituição</span></div>
+        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /><span>Estatísticas</span></div>
+        <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /><span>Tarefas</span></div>
+      </div>
     </section>
     <section id="tasks" class="page">
       <h1>Tarefas</h1>
@@ -88,6 +96,10 @@
       <h1>Histórico</h1>
       <p>Em desenvolvimento...</p>
     </section>
+    <section id="constitution" class="page">
+      <h1>Constituição</h1>
+      <div id="constitution-content"></div>
+    </section>
   </main>
 
   <div id="task-modal" class="hidden">
@@ -96,7 +108,7 @@
       <input type="text" id="task-title" placeholder="Título" />
       <textarea id="task-desc" placeholder="Descrição"></textarea>
       <input type="datetime-local" id="task-datetime" />
-      <input type="text" id="task-aspect" placeholder="Aspecto" />
+      <select id="task-aspect"></select>
       <button id="save-task">Salvar</button>
       <button id="cancel-task">Cancelar</button>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -127,14 +127,19 @@ li:hover { transform: scale(1.02); }
 .header-container {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   padding: 10px 20px;
+  position: relative;
 }
 
 .header-right {
   display: flex;
   align-items: center;
   gap: 10px;
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .theme-toggle {
@@ -146,9 +151,31 @@ li:hover { transform: scale(1.02); }
   filter: brightness(0) invert(1);
 }
 
+#logo-screen #logo {
+  width: 300px;
+  max-width: 80%;
+  height: auto;
+  filter: none;
+}
+
+#logo-text {
+  font-size: 24px;
+  margin-top: 20px;
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+#logo-text.show {
+  opacity: 1;
+}
+
 .menu-button {
   cursor: pointer;
   font-size: 24px;
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .time-display {
@@ -163,6 +190,37 @@ li:hover { transform: scale(1.02); }
   background: var(--dropdown-bg);
   display: none;
   flex-direction: column;
+}
+
+.aspect-image {
+  width: 300px;
+  max-width: 80%;
+  height: auto;
+  margin: 20px 0;
+}
+
+.slider-feedback {
+  margin-top: 20px;
+  font-size: 20px;
+  text-align: center;
+}
+
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  justify-items: center;
+  padding: 40px 0;
+}
+
+.menu-item {
+  text-align: center;
+  cursor: pointer;
+}
+
+.menu-item img {
+  width: 100px;
+  height: 100px;
 }
 
 .dropdown.show {
@@ -262,7 +320,7 @@ li:hover { transform: scale(1.02); }
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,128,0.8);
+  background: rgba(0,0,0,0.8);
   display: none;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Add animated splash screen with central logo and motivational tagline
- Revamp question flow with aspect images and 0-100 slider feedback
- Introduce icon-based home menu and long-press task editing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a132be7e9c8325a3553b5643cd6158