### PR TITLE
Revamp menu layout and task interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>Presidencial</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="light">
+<body class="dark">
   <div id="logo-screen" class="center">
     <img src="logo.png" alt="Logo" id="logo" />
     <p id="logo-text" class="hidden">Construa a si mesmo</p>
@@ -35,8 +35,9 @@
   <header id="main-header" class="hidden">
     <div class="header-container">
       <div id="menu-button" class="menu-button">☰</div>
-      <img src="logo.png" alt="Logo" class="header-logo" />
+      <img src="logo.png" alt="Logo" class="header-logo" id="header-logo" />
       <div class="header-right">
+        <div id="date-display" class="date-display"></div>
         <div id="time-display" class="time-display"></div>
         <button id="theme-toggle" class="theme-toggle">🌙</button>
       </div>
@@ -54,12 +55,12 @@
   <main id="main-content" class="hidden">
     <section id="menu" class="page active">
       <div class="menu-grid">
-        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /><span>Histórico</span></div>
-        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /><span>Mindset</span></div>
-        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /><span>Leis</span></div>
-        <div class="menu-item" data-page="constitution"><img src="constituicao.png" alt="Constituição" /><span>Constituição</span></div>
-        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /><span>Estatísticas</span></div>
         <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /><span>Tarefas</span></div>
+        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /><span>Leis</span></div>
+        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /><span>Estatísticas</span></div>
+        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /><span>Mindset</span></div>
+        <div class="menu-item" data-page="constitution"><img src="constituicao.png" alt="Constituição" /><span>Constituição</span></div>
+        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /><span>Histórico</span></div>
       </div>
     </section>
     <section id="tasks" class="page">
@@ -82,6 +83,10 @@
     </section>
     <section id="laws" class="page">
       <h1>Leis</h1>
+      <div id="laws-hub">
+        <button id="add-law-btn">Nova lei</button>
+        <select id="law-aspect"></select>
+      </div>
       <div id="laws-list"></div>
     </section>
     <section id="stats" class="page">
@@ -110,6 +115,7 @@
       <input type="datetime-local" id="task-datetime" />
       <select id="task-aspect"></select>
       <button id="save-task">Salvar</button>
+      <button id="complete-task" class="hidden">Concluir</button>
       <button id="cancel-task">Cancelar</button>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -148,7 +148,6 @@ li:hover { transform: scale(1.02); }
 
 .header-logo {
   height: 40px;
-  filter: brightness(0) invert(1);
 }
 
 #logo-screen #logo {
@@ -207,7 +206,6 @@ li:hover { transform: scale(1.02); }
 
 .menu-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, 150px);
   gap: 40px;
   justify-content: center;
   justify-items: center;
@@ -227,6 +225,11 @@ li:hover { transform: scale(1.02); }
 .menu-item img {
   width: 150px;
   height: 150px;
+  transition: transform 0.3s ease;
+}
+
+.menu-item:hover img {
+  transform: scale(1.05);
 }
 
 .menu-item span {
@@ -265,10 +268,23 @@ li:hover { transform: scale(1.02); }
 .page.active { display: block; }
 
 .task-item {
-  background: rgba(0,0,0,0.05);
   padding: 10px;
   margin-bottom: 10px;
   border-radius: 8px;
+}
+
+.task-item.pending {
+  background: linear-gradient(135deg, #40E0D0, #7FFFD4);
+}
+
+.task-item.overdue {
+  background: linear-gradient(135deg, #FF5F6D, #FFC371);
+}
+
+.task-item.completed {
+  background: linear-gradient(135deg, #58D68D, #A9DFBF);
+  opacity: 0.8;
+  text-decoration: line-through;
 }
 
 .task-item h3 {
@@ -289,13 +305,12 @@ li:hover { transform: scale(1.02); }
   margin-bottom: 20px;
 }
 
-.task-item.overdue {
-  border: 2px solid red;
+#laws-hub {
+  margin-bottom: 20px;
 }
 
-.task-item.completed {
-  opacity: 0.6;
-  text-decoration: line-through;
+.date-display {
+  font-size: 16px;
 }
 
 @keyframes fade {
@@ -374,6 +389,30 @@ li:hover { transform: scale(1.02); }
   #progress-bar { border-radius: 3px; }
   .header-logo { height: 32px; }
   .menu-button { font-size: 20px; }
-  .time-display { font-size: 14px; }
+  .time-display, .date-display { font-size: 14px; }
   .header-container { padding: 10px; }
+  .menu-grid {
+    grid-template-columns: repeat(2, 300px);
+    gap: 20px;
+  }
+  .menu-item img {
+    width: 300px;
+    height: 300px;
+    animation: float 3s ease-in-out infinite alternate;
+  }
+}
+
+@media (min-width: 601px) {
+  .menu-grid {
+    grid-template-columns: repeat(3, 225px);
+  }
+  .menu-item img {
+    width: 225px;
+    height: 225px;
+  }
+}
+
+@keyframes float {
+  from { transform: scale(1); }
+  to { transform: scale(1.05); }
 }


### PR DESCRIPTION
## Summary
- Set dark theme as default and show date in header
- Reorder and resize menu icons for desktop and mobile
- Color-code tasks with long-press edit/completion dialog
- Add hub to create new laws per aspect

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a155a8bb5c8325ab3bc8b51cee19bf