### PR TITLE
feat: enhance mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Presidencial</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/styles.css
+++ b/styles.css
@@ -274,7 +274,7 @@ li:hover { transform: scale(1.02); }
 }
 
 .task-item.pending {
-  background: linear-gradient(135deg, #40E0D0, #7FFFD4);
+    background: linear-gradient(135deg, #00A2E8, #33B8FF);
 }
 
 .task-item.overdue {
@@ -282,9 +282,7 @@ li:hover { transform: scale(1.02); }
 }
 
 .task-item.completed {
-  background: linear-gradient(135deg, #58D68D, #A9DFBF);
-  opacity: 0.8;
-  text-decoration: line-through;
+    background: linear-gradient(135deg, #44B816, #6CD932);
 }
 
 .task-item h3 {
@@ -380,17 +378,18 @@ li:hover { transform: scale(1.02); }
 }
 
 @media (max-width: 600px) {
-  h1 { font-size: 28px; }
-  h2 { font-size: 20px; }
-  p, span, label, input, button, li { font-size: 16px; }
-  button { font-size: 14px; width: 100%; height: 48px; }
+  body { overflow: hidden; }
+  h1 { font-size: 96px; }
+  h2 { font-size: 48px; }
+  p, span, label, input, button, li { font-size: 36px; }
+  button { font-size: 32px; width: 100%; height: 96px; padding: 20px 40px; }
   #slider, #stats-slider { width: 100%; }
-  .progress-container { height: 6px; }
-  #progress-bar { border-radius: 3px; }
-  .header-logo { height: 32px; }
-  .menu-button { font-size: 20px; }
-  .time-display, .date-display { font-size: 14px; }
-  .header-container { padding: 10px; }
+  .progress-container { height: 16px; }
+  #progress-bar { border-radius: 8px; }
+  .header-logo { height: 80px; }
+  .menu-button { font-size: 40px; }
+  .time-display, .date-display { font-size: 32px; }
+  .header-container { padding: 20px; }
   .menu-grid {
     grid-template-columns: repeat(2, 300px);
     gap: 20px;
@@ -400,6 +399,9 @@ li:hover { transform: scale(1.02); }
     height: 300px;
     animation: float 3s ease-in-out infinite alternate;
   }
+  .task-item h3 { font-size: 40px; }
+  .task-item span { font-size: 28px; }
+  .task-form { padding: 40px; max-width: 800px; }
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
## Summary
- enlarge mobile UI elements and block scrolling
- tune task colors and remove strike-through on completion
- add viewport meta tag for responsive mobile scaling

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a15a05ff4083259e847b04bd7a5b35