### PR TITLE
feat: optimize mobile layout and disable copying

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,23 @@ let previousLogin = 0;
 let draggedIndex = null;
 let editingTaskIndex = null;
 
+// Prevent copying, context menu, and zoom interactions
+document.addEventListener('contextmenu', e => e.preventDefault());
+document.addEventListener('copy', e => e.preventDefault());
+document.addEventListener('cut', e => e.preventDefault());
+document.addEventListener('paste', e => e.preventDefault());
+document.addEventListener('selectstart', e => e.preventDefault());
+document.addEventListener('wheel', e => { if (e.ctrlKey) e.preventDefault(); }, { passive: false });
+document.addEventListener('gesturestart', e => e.preventDefault());
+document.addEventListener('gesturechange', e => e.preventDefault());
+document.addEventListener('gestureend', e => e.preventDefault());
+document.addEventListener('touchmove', e => { if (e.touches.length > 1) e.preventDefault(); }, { passive: false });
+document.addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && ['c', 'x', 'v', 'a', '+', '-', '0'].includes(e.key.toLowerCase())) {
+    e.preventDefault();
+  }
+});
+
 const slider = document.getElementById('slider');
 const sliderFeedback = document.getElementById('slider-feedback');
 const aspectImage = document.getElementById('aspect-image');

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Presidencial</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,11 @@ body {
   color: var(--text-color);
   font-family: 'Lato', sans-serif;
   margin: 0;
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
 }
 
 .center {
@@ -378,7 +383,10 @@ li:hover { transform: scale(1.02); }
 }
 
 @media (max-width: 600px) {
-  body { overflow: hidden; }
+  body {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
   h1 { font-size: 96px; }
   h2 { font-size: 48px; }
   p, span, label, input, button, li { font-size: 36px; }
@@ -390,13 +398,27 @@ li:hover { transform: scale(1.02); }
   .menu-button { font-size: 40px; }
   .time-display, .date-display { font-size: 32px; }
   .header-container { padding: 20px; }
-  .menu-grid {
-    grid-template-columns: repeat(2, 300px);
-    gap: 20px;
+  #menu {
+    height: calc(100vh - 80px);
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 80px 20px 0;
   }
-  .menu-item img {
-    width: 300px;
-    height: 300px;
+  #menu .menu-grid {
+    width: 100%;
+    height: 100%;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    padding: 0 20px;
+    box-sizing: border-box;
+    justify-items: center;
+    align-content: center;
+  }
+  #menu .menu-item img {
+    width: 80%;
+    height: auto;
     animation: float 3s ease-in-out infinite alternate;
   }
   .task-item h3 { font-size: 40px; }


### PR DESCRIPTION
## Summary
- enforce fixed 100% zoom and responsive mobile menu
- block text selection, context menus, and zoom shortcuts
- refine mobile layout without initial scrolling

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15be33c848325a9e6a85fee6bf8ee