### PR TITLE
Simplify header and add mobile carousel

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,9 +33,6 @@ const aspectImage = document.getElementById('aspect-image');
 const statsSlider = document.getElementById('stats-slider');
 const statsSliderValue = document.getElementById('stats-slider-value');
 
-const menuButton = document.getElementById('menu-button');
-const menuDropdown = document.getElementById('menu-dropdown');
-const themeToggle = document.getElementById('theme-toggle');
 const addTaskBtn = document.getElementById('add-task-btn');
 const taskModal = document.getElementById('task-modal');
 const taskTitleInput = document.getElementById('task-title');
@@ -48,20 +45,9 @@ const completeTaskBtn = document.getElementById('complete-task');
 const addLawBtn = document.getElementById('add-law-btn');
 const lawAspectInput = document.getElementById('law-aspect');
 const headerLogo = document.getElementById('header-logo');
-const dateDisplay = document.getElementById('date-display');
+const menuCarousel = document.getElementById('menu-carousel');
 
-const savedTheme = localStorage.getItem('theme') || 'dark';
-document.body.classList.remove('light', 'dark');
-document.body.classList.add(savedTheme);
-themeToggle.textContent = savedTheme === 'light' ? '🌙' : '☀️';
-
-themeToggle.addEventListener('click', () => {
-  const newTheme = document.body.classList.contains('light') ? 'dark' : 'light';
-  document.body.classList.remove('light', 'dark');
-  document.body.classList.add(newTheme);
-  localStorage.setItem('theme', newTheme);
-  themeToggle.textContent = newTheme === 'light' ? '🌙' : '☀️';
-});
+document.body.classList.add('dark');
 headerLogo.addEventListener('click', () => showPage('menu'));
 
 Promise.all([
@@ -200,10 +186,11 @@ function initApp(firstTime) {
   scheduleNotifications();
   document.getElementById('main-header').classList.remove('hidden');
   document.getElementById('main-content').classList.remove('hidden');
-  updateTime();
-  setInterval(updateTime, 1000);
   setInterval(checkStatsPrompt, 60000);
   checkStatsPrompt();
+  if (window.innerWidth <= 600) {
+    initCarousel();
+  }
 }
 
 function createInitialTasks(startTime) {
@@ -404,43 +391,53 @@ function scheduleNotifications() {
   });
 }
 
-function updateTime() {
-  const now = new Date();
-  document.getElementById('time-display').textContent = now.toLocaleTimeString();
-  dateDisplay.textContent = now.toLocaleDateString();
-}
-
-let hideMenuTimeout;
-function showMenu() {
-  clearTimeout(hideMenuTimeout);
-  menuDropdown.classList.add('show');
-}
-function scheduleHideMenu() {
-  clearTimeout(hideMenuTimeout);
-  hideMenuTimeout = setTimeout(() => menuDropdown.classList.remove('show'), 2000);
-}
-menuButton.addEventListener('mouseenter', showMenu);
-menuButton.addEventListener('mouseleave', scheduleHideMenu);
-menuButton.addEventListener('click', () => {
-  clearTimeout(hideMenuTimeout);
-  menuDropdown.classList.toggle('show');
-});
-menuDropdown.addEventListener('mouseenter', showMenu);
-menuDropdown.addEventListener('mouseleave', scheduleHideMenu);
-
-document.querySelectorAll('#menu-dropdown a').forEach(a => {
-  a.addEventListener('click', e => {
-    showPage(e.target.getAttribute('data-page'));
-    menuDropdown.classList.remove('show');
-  });
-});
-
 document.querySelectorAll('.menu-item').forEach(item => {
   item.addEventListener('click', e => {
     const page = e.currentTarget.getAttribute('data-page');
     showPage(page);
   });
 });
+
+function initCarousel() {
+  const items = [
+    { page: 'tasks', img: 'acoes.png', label: 'Tarefas' },
+    { page: 'laws', img: 'leis.png', label: 'Leis' },
+    { page: 'stats', img: 'estatisticas.png', label: 'Estatísticas' },
+    { page: 'mindset', img: 'mindset.png', label: 'Mindset' },
+    { page: 'constitution', img: 'constituicao.png', label: 'Constituição' },
+    { page: 'history', img: 'historico.png', label: 'Histórico' }
+  ];
+  let idx = 0;
+  const img = document.createElement('img');
+  const span = document.createElement('span');
+  menuCarousel.appendChild(img);
+  menuCarousel.appendChild(span);
+
+  function render() {
+    const item = items[idx];
+    img.src = item.img;
+    img.alt = item.label;
+    span.textContent = item.label;
+    showPage(item.page);
+  }
+
+  render();
+
+  let startX = 0;
+  menuCarousel.addEventListener('touchstart', e => {
+    startX = e.touches[0].clientX;
+  });
+  menuCarousel.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - startX;
+    if (dx > 50) {
+      idx = (idx - 1 + items.length) % items.length;
+      render();
+    } else if (dx < -50) {
+      idx = (idx + 1) % items.length;
+      render();
+    }
+  });
+}
 
 function showPage(pageId) {
   document.querySelectorAll('.page').forEach(sec => sec.classList.remove('active'));

--- a/index.html
+++ b/index.html
@@ -35,25 +35,12 @@
 
   <header id="main-header" class="hidden">
     <div class="header-container">
-      <div id="menu-button" class="menu-button">☰</div>
       <img src="logo.png" alt="Logo" class="header-logo" id="header-logo" />
-      <div class="header-right">
-        <div id="date-display" class="date-display"></div>
-        <div id="time-display" class="time-display"></div>
-        <button id="theme-toggle" class="theme-toggle">🌙</button>
-      </div>
     </div>
-    <nav id="menu-dropdown" class="dropdown hidden">
-      <a data-page="menu">Menu</a>
-      <a data-page="tasks">Tarefas</a>
-      <a data-page="laws">Leis</a>
-      <a data-page="stats">Estatísticas</a>
-      <a data-page="mindset">Mindset</a>
-      <a data-page="history">Histórico</a>
-    </nav>
   </header>
 
   <main id="main-content" class="hidden">
+    <div id="menu-carousel" class="menu-carousel"></div>
     <section id="menu" class="page active">
       <div class="menu-grid">
         <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /><span>Tarefas</span></div>

--- a/styles.css
+++ b/styles.css
@@ -11,17 +11,6 @@
   font-style: normal;
 }
 
-.light {
-  --bg-color: #fff;
-  --text-color: #222;
-  --button-bg: #C8A951;
-  --button-hover-bg: #b09145;
-  --header-bg: linear-gradient(to bottom, #000, #b09145);
-  --header-text: #fff;
-  --dropdown-bg: #000;
-  --dropdown-hover-bg: #333;
-}
-
 .dark {
   --bg-color: #222;
   --text-color: #eee;
@@ -137,20 +126,6 @@ li:hover { transform: scale(1.02); }
   position: relative;
 }
 
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  position: absolute;
-  right: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.theme-toggle {
-  padding: 5px 10px;
-}
-
 .header-logo {
   height: 40px;
 }
@@ -173,29 +148,6 @@ li:hover { transform: scale(1.02); }
   opacity: 1;
 }
 
-.menu-button {
-  cursor: pointer;
-  font-size: 24px;
-  position: absolute;
-  left: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.time-display {
-  font-size: 16px;
-}
-
-.dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
-  background: var(--dropdown-bg);
-  display: none;
-  flex-direction: column;
-}
-
 .aspect-image {
   width: 300px;
   max-width: 80%;
@@ -207,6 +159,24 @@ li:hover { transform: scale(1.02); }
   margin-top: 20px;
   font-size: 20px;
   text-align: center;
+}
+
+.menu-carousel {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-top: 20px;
+}
+
+.menu-carousel img {
+  width: 150px;
+  height: 150px;
+  transition: transform 0.3s ease;
+}
+
+.menu-carousel span {
+  margin-top: 10px;
 }
 
 .menu-grid {
@@ -239,27 +209,6 @@ li:hover { transform: scale(1.02); }
 
 .menu-item span {
   margin-top: 10px;
-}
-
-.dropdown.show {
-  display: flex;
-  animation: slideDown 0.3s ease;
-}
-
-.dropdown a {
-  padding: 10px;
-  text-align: center;
-  color: var(--header-text);
-  text-decoration: none;
-}
-
-.dropdown a:hover {
-  background: var(--dropdown-hover-bg);
-}
-
-@keyframes slideDown {
-  from { opacity: 0; transform: translateY(-10px); }
-  to { opacity: 1; transform: translateY(0); }
 }
 
 .page {
@@ -310,10 +259,6 @@ li:hover { transform: scale(1.02); }
 
 #laws-hub {
   margin-bottom: 20px;
-}
-
-.date-display {
-  font-size: 16px;
 }
 
 @keyframes fade {
@@ -391,39 +336,28 @@ li:hover { transform: scale(1.02); }
   h2 { font-size: 48px; }
   p, span, label, input, button, li { font-size: 36px; }
   button { font-size: 32px; width: 100%; height: 96px; padding: 20px 40px; }
+  #main-header { height: 60px; }
+  .header-logo { height: 60px; }
+  .header-container { padding: 15px; }
+  #main-content h1 { font-size: 72px; }
+  #main-content h2 { font-size: 36px; }
+  #main-content p,
+  #main-content span,
+  #main-content label,
+  #main-content input,
+  #main-content button,
+  #main-content li { font-size: 27px; }
+  #main-content button { font-size: 24px; height: 72px; padding: 15px 30px; }
   #slider, #stats-slider { width: 100%; }
-  .progress-container { height: 16px; }
-  #progress-bar { border-radius: 8px; }
-  .header-logo { height: 80px; }
-  .menu-button { font-size: 40px; }
-  .time-display, .date-display { font-size: 32px; }
-  .header-container { padding: 20px; }
-  #menu {
-    height: calc(100vh - 80px);
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 80px 20px 0;
-  }
-  #menu .menu-grid {
-    width: 100%;
-    height: 100%;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 20px;
-    padding: 0 20px;
-    box-sizing: border-box;
-    justify-items: center;
-    align-content: center;
-  }
-  #menu .menu-item img {
-    width: 80%;
-    height: auto;
-    animation: float 3s ease-in-out infinite alternate;
-  }
-  .task-item h3 { font-size: 40px; }
-  .task-item span { font-size: 28px; }
-  .task-form { padding: 40px; max-width: 800px; }
+  .progress-container { height: 12px; }
+  #progress-bar { border-radius: 6px; }
+  .menu-grid { display: none; }
+  .menu-carousel { display: flex; }
+  #menu { display: none; }
+  .page { padding: 60px 15px 15px; }
+  .task-item h3 { font-size: 30px; }
+  .task-item span { font-size: 21px; }
+  .task-form { padding: 30px; max-width: 600px; }
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
## Summary
- Remove header menu, date/time display and theme switch to keep a clean dark-only header
- Introduce a mobile swipe carousel that shows one menu option at a time and loads pages below
- Scale mobile text and elements down by 25% for a more compact layout

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a15f7a61408325b4bbb4c0169da9ac