### PR TITLE
Add suggestion buttons for tasks, laws and mindsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
       <h1>Tarefas</h1>
       <div id="tasks-hub">
         <button id="add-task-btn">Nova tarefa</button>
+        <button id="suggest-task-btn">Ver ideias</button>
       </div>
       <div id="tasks-pending">
         <h2>Pendentes</h2>
@@ -73,6 +74,7 @@
       <h1>Leis</h1>
       <div id="laws-hub">
         <button id="add-law-btn">Nova lei</button>
+        <button id="suggest-law-btn">Ver ideias</button>
         <select id="law-aspect"></select>
       </div>
       <div id="laws-list"></div>
@@ -83,6 +85,11 @@
     </section>
     <section id="mindset" class="page">
       <h1>Mindset</h1>
+      <div id="mindset-hub">
+        <button id="add-mindset-btn">Criar mindset</button>
+        <button id="suggest-mindset-btn">Ver ideias</button>
+        <select id="mindset-aspect"></select>
+      </div>
       <div id="mindset-content"></div>
     </section>
     <section id="history" class="page">


### PR DESCRIPTION
## Summary
- Allow creation and suggestion of mindsets via new dialog and JSON ideas
- Provide law suggestions and creation flow based on leis.json
- Add task idea button that pre-fills the task form from tarefas.json

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2333d4a908325aa93f38a7bd15ef8