### PR TITLE
feat: add custom modals for laws and mindset

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,6 @@
       <div id="laws-hub">
         <button id="add-law-btn">Nova lei</button>
         <button id="suggest-law-btn">Ver ideias</button>
-        <select id="law-aspect"></select>
       </div>
       <div id="laws-list"></div>
     </section>
@@ -88,7 +87,6 @@
       <div id="mindset-hub">
         <button id="add-mindset-btn">Criar mindset</button>
         <button id="suggest-mindset-btn">Ver ideias</button>
-        <select id="mindset-aspect"></select>
       </div>
       <div id="mindset-content"></div>
     </section>
@@ -109,9 +107,53 @@
       <textarea id="task-desc" placeholder="Descrição"></textarea>
       <input type="datetime-local" id="task-datetime" />
       <select id="task-aspect"></select>
+      <select id="task-type">
+        <option value="Hábito">Hábito</option>
+        <option value="Tarefa">Tarefa</option>
+      </select>
       <button id="save-task">Salvar</button>
       <button id="complete-task" class="hidden">Concluir</button>
       <button id="cancel-task">Cancelar</button>
+    </div>
+  </div>
+
+  <div id="law-modal" class="hidden">
+    <div class="task-form">
+      <h2>Nova lei</h2>
+      <input type="text" id="law-title" placeholder="Nome da lei" maxlength="24" />
+      <textarea id="law-desc" placeholder="Descrição (até 60 caracteres)" maxlength="60"></textarea>
+      <select id="law-aspect-select"></select>
+      <div class="modal-buttons">
+        <button id="save-law">Salvar</button>
+        <button id="accept-law" class="hidden accept-btn">Aceitar</button>
+        <button id="decline-law" class="hidden decline-btn">Declinar</button>
+        <button id="cancel-law">Cancelar</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="law-action-modal" class="hidden">
+    <div class="task-form">
+      <h2>Lei</h2>
+      <button id="revoke-law" class="decline-btn">Revogar</button>
+      <button id="cancel-law-action">Voltar</button>
+    </div>
+  </div>
+
+  <div id="mindset-modal" class="hidden">
+    <div class="task-form">
+      <h2>Novo mindset</h2>
+      <input type="text" id="mindset-title" placeholder="Título" maxlength="24" />
+      <textarea id="mindset-desc" placeholder="Descrição (até 60 caracteres)" maxlength="60"></textarea>
+      <label for="mindset-rate">Importância: <span id="mindset-rate-value">50</span></label>
+      <input type="range" id="mindset-rate" min="0" max="100" value="50" />
+      <select id="mindset-aspect-select"></select>
+      <div class="modal-buttons">
+        <button id="save-mindset">Salvar</button>
+        <button id="accept-mindset" class="hidden accept-btn">Aceitar</button>
+        <button id="decline-mindset" class="hidden decline-btn">Declinar</button>
+        <button id="cancel-mindset">Cancelar</button>
+      </div>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -338,6 +338,27 @@ li:hover { transform: scale(1.02); }
   display: flex;
 }
 
+#law-modal,
+#mindset-modal,
+#law-action-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+}
+
+#law-modal.show,
+#mindset-modal.show,
+#law-action-modal.show {
+  display: flex;
+}
+
 .task-form {
   background: var(--bg-color);
   color: var(--text-color);
@@ -359,6 +380,36 @@ li:hover { transform: scale(1.02); }
 
 .task-form button {
   width: 100%;
+}
+
+.modal-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.law-box,
+.mindset-box {
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.accept-btn {
+  background: #44B816;
+}
+
+.accept-btn:hover {
+  background: #6CD932;
+}
+
+.decline-btn {
+  background: #FF5F6D;
+}
+
+.decline-btn:hover {
+  background: #FFC371;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- replace browser prompts with custom modals for laws and mindset
- add type dropdown for tasks and aspect selections within modals
- style new modals with accept/decline options and colored boxes

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a249d608d083259eee268fb890d43d