### PR TITLE
refactor: improve mobile layout and spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,7 @@ body {
   justify-content: center;
   height: 100vh;
   text-align: center;
+  padding: 0 30px;
 }
 
 .hidden { display: none; }
@@ -122,7 +123,7 @@ li:hover { transform: scale(1.02); }
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 20px;
+  padding: 10px 30px;
   position: relative;
 }
 
@@ -213,7 +214,7 @@ li:hover { transform: scale(1.02); }
 
 .page {
   display: none;
-  padding: 80px 20px 20px;
+  padding: 80px 30px 20px;
   max-width: 1280px;
   margin: 0 auto;
   animation: fade 0.3s ease;
@@ -364,7 +365,7 @@ li:hover { transform: scale(1.02); }
   color: var(--text-color);
   padding: 20px;
   border-radius: 8px;
-  width: 90%;
+  width: calc(100% - 60px);
   max-width: 400px;
   display: flex;
   flex-direction: column;
@@ -417,32 +418,28 @@ li:hover { transform: scale(1.02); }
     overflow-x: hidden;
     overflow-y: auto;
   }
-  h1 { font-size: 96px; }
-  h2 { font-size: 48px; }
-  p, span, label, input, button, li { font-size: 36px; }
-  button { font-size: 32px; width: 100%; height: 96px; padding: 20px 40px; }
-  #main-header { height: 60px; }
-  .header-logo { height: 60px; }
-  .header-container { padding: 15px; }
-  #main-content h1 { font-size: 72px; }
-  #main-content h2 { font-size: 36px; }
-  #main-content p,
-  #main-content span,
-  #main-content label,
-  #main-content input,
-  #main-content button,
-  #main-content li { font-size: 27px; }
-  #main-content button { font-size: 24px; height: 72px; padding: 15px 30px; }
-  #slider, #stats-slider { width: 100%; }
-  .progress-container { height: 12px; }
-  #progress-bar { border-radius: 6px; }
+  h1 { font-size: 29px; }
+  h2 { font-size: 14px; }
+  p, span, label, input, button, li { font-size: 11px; }
+  button { font-size: 10px; padding: 7px 14px; }
+  #logo-screen #logo,
+  .aspect-image { width: 210px; }
+  .menu-item img,
+  .menu-carousel img { width: 105px; height: 105px; }
+  #main-header { height: 42px; }
+  .header-container { padding: 7px 30px; }
+  .header-logo { height: 28px; }
+  #slider, #stats-slider { width: 210px; }
+  .progress-container { height: 6px; }
+  #progress-bar { border-radius: 3px; }
   .menu-grid { display: none; }
   .menu-carousel { display: flex; }
   #menu { display: none; }
-  .page { padding: 60px 15px 15px; }
-  .task-item h3 { font-size: 30px; }
-  .task-item span { font-size: 21px; }
-  .task-form { padding: 30px; max-width: 600px; }
+  .page { padding: 90px 30px 15px; }
+  .page > h1 { display: none; }
+  .task-item h3 { font-size: 12px; }
+  .task-item span { font-size: 9px; }
+  .task-form { padding: 14px; max-width: 280px; }
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
## Summary
- enforce 30px side margins and centered layout
- scale down elements and text on mobile
- hide section titles on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a25547cfd08325a570275269a1d641