### PR TITLE
Rename constitution menu to options and simplify idea suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /><span>Leis</span></div>
         <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /><span>Estatísticas</span></div>
         <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /><span>Mindset</span></div>
-        <div class="menu-item" data-page="constitution"><img src="constituicao.png" alt="Constituição" /><span>Constituição</span></div>
+        <div class="menu-item" data-page="options"><img src="constituicao.png" alt="Opções" /><span>Opções</span></div>
         <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /><span>Histórico</span></div>
       </div>
     </section>
@@ -94,9 +94,9 @@
       <h1>Histórico</h1>
       <p>Em desenvolvimento...</p>
     </section>
-    <section id="constitution" class="page">
-      <h1>Constituição</h1>
-      <div id="constitution-content"></div>
+    <section id="options" class="page">
+      <h1>Opções</h1>
+      <div id="options-content"></div>
     </section>
   </main>
 
@@ -152,6 +152,7 @@
         <button id="save-mindset">Salvar</button>
         <button id="accept-mindset" class="hidden accept-btn">Aceitar</button>
         <button id="decline-mindset" class="hidden decline-btn">Declinar</button>
+        <button id="delete-mindset" class="hidden decline-btn">Remover</button>
         <button id="cancel-mindset">Cancelar</button>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,24 @@ button {
 }
 button:hover { background: var(--button-hover-bg); }
 
+select {
+  height: 40px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font-family: 'Lato', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  border: none;
+  border-radius: 8px;
+  padding: 0 8px;
+}
+
+@media (max-width: 600px) {
+  select {
+    height: 25px;
+  }
+}
+
 .slider-container { margin: 20px 0; }
 #slider { width: 300px; }
 


### PR DESCRIPTION
## Summary
- Rename Constituição menu to user Options
- Drop modal popups for "Ver ideias"; suggestions now add directly to lists
- Allow editing or removing mindsets via double-click or long press and style dropdowns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f37c75c8325a237475dd6ffaf5e