### PR TITLE
Add daily schedule view and restore aspect images

### DIFF
--- a/data/aspects.json
+++ b/data/aspects.json
@@ -1,5 +1,6 @@
 {
   "Water": {
+    "image": "aspect1.png",
     "importanceQuestion": "De 1 a 10, qual a importância da sua hidratação diária para o seu bem-estar?",
     "levelQuestion": "Qual o nível atual da sua hidratação diária hoje?",
     "speech": "Comprometo-me a manter meu corpo hidratado, combustível vital para a liderança da minha vida.",
@@ -10,6 +11,7 @@
     ]
   },
   "Nutrition": {
+    "image": "aspect2.png",
     "importanceQuestion": "De 1 a 10, qual a importância de manter uma alimentação equilibrada para sua vida?",
     "levelQuestion": "Qual o nível atual da sua alimentação equilibrada hoje?",
     "speech": "Prometo alimentar meu corpo com equilíbrio para sustentar força e clareza mental.",
@@ -20,6 +22,7 @@
     ]
   },
   "Sleep": {
+    "image": "aspect3.png",
     "importanceQuestion": "De 1 a 10, quão essencial é ter um sono de qualidade para seu desempenho diário?",
     "levelQuestion": "Qual o nível atual da qualidade do seu sono hoje?",
     "speech": "Defendo o sono de qualidade como pilar de energia e decisões acertadas.",
@@ -30,6 +33,7 @@
     ]
   },
   "Hygiene": {
+    "image": "aspect4.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter bons hábitos de higiene para sua saúde?",
     "levelQuestion": "Qual o nível atual dos seus hábitos de higiene hoje?",
     "speech": "Manterei a higiene como escudo contra doenças e base para a confiança.",
@@ -40,6 +44,7 @@
     ]
   },
   "Emocional": {
+    "image": "aspect5.png",
     "importanceQuestion": "De 1 a 10, como você valoriza o autocontrole emocional e a resiliência?",
     "levelQuestion": "Qual o nível atual do seu autocontrole emocional hoje?",
     "speech": "Cultivarei autocontrole e resiliência para governar minha mente com sabedoria.",
@@ -50,6 +55,7 @@
     ]
   },
   "Mindfulness": {
+    "image": "aspect6.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter foco e presença plena no dia a dia?",
     "levelQuestion": "Qual o nível atual do seu foco e presença hoje?",
     "speech": "Manterei foco e presença para honrar cada momento com intenção.",
@@ -60,6 +66,7 @@
     ]
   },
   "Learning": {
+    "image": "aspect7.png",
     "importanceQuestion": "De 1 a 10, como você valoriza aprender coisas novas constantemente?",
     "levelQuestion": "Qual o nível atual do seu aprendizado constante hoje?",
     "speech": "Investirei no aprendizado contínuo como chave para minha evolução.",
@@ -70,6 +77,7 @@
     ]
   },
   "Family": {
+    "image": "aspect8.png",
     "importanceQuestion": "De 1 a 10, quão importante é cuidar dos seus vínculos familiares?",
     "levelQuestion": "Qual o nível atual do cuidado com seus vínculos familiares hoje?",
     "speech": "Preservarei e fortalecerei meus laços familiares como núcleo de apoio.",
@@ -80,6 +88,7 @@
     ]
   },
   "Relationships": {
+    "image": "aspect9.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter relações externas saudáveis?",
     "levelQuestion": "Qual o nível atual das suas relações externas hoje?",
     "speech": "Construirei conexões saudáveis que ampliem minha visão e força.",
@@ -90,6 +99,7 @@
     ]
   },
   "Financial": {
+    "image": "aspect10.png",
     "importanceQuestion": "De 1 a 10, como você valoriza sua segurança e liberdade financeira?",
     "levelQuestion": "Qual o nível atual da sua segurança e liberdade financeira hoje?",
     "speech": "Buscarei estabilidade financeira para garantir minha liberdade de escolha.",
@@ -100,6 +110,7 @@
     ]
   },
   "Purpose": {
+    "image": "aspect11.png",
     "importanceQuestion": "De 1 a 10, quão importante é ter propósito e metas de vida claras?",
     "levelQuestion": "Qual o nível atual de clareza do seu propósito e metas hoje?",
     "speech": "Viverei com propósito e metas claras, guiando cada passo com sentido.",
@@ -110,6 +121,7 @@
     ]
   },
   "Contribution": {
+    "image": "aspect12.png",
     "importanceQuestion": "De 1 a 10, como você valoriza contribuir para o mundo de forma positiva?",
     "levelQuestion": "Qual o nível atual da sua contribuição positiva hoje?",
     "speech": "Contribuirei para um mundo melhor, deixando marcas positivas.",

--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
     </section>
     <section id="tasks" class="page">
       <h1>Tarefas</h1>
+      <div id="day-schedule">
+        <h2 id="schedule-title"></h2>
+        <div id="schedule-carousel"></div>
+      </div>
       <div id="tasks-hub">
         <button id="add-task-btn">Nova tarefa</button>
         <button id="suggest-task-btn">Ver ideias</button>

--- a/js/main.js
+++ b/js/main.js
@@ -180,7 +180,7 @@ function initApp(firstTime) {
     responses = JSON.parse(localStorage.getItem('responses') || '{}');
   }
   buildOptions();
-  initTasks(aspectKeys, tasksData);
+  initTasks(aspectKeys, tasksData, aspectsData);
   initLaws(aspectKeys, lawsData, statsColors);
   initStats(aspectKeys, responses, statsColors);
   initMindset(aspectKeys, mindsetData, statsColors);

--- a/styles.css
+++ b/styles.css
@@ -415,6 +415,64 @@ li:hover { transform: scale(1.02); }
   color: #fff;
 }
 
+#day-schedule {
+  margin-top: 20px;
+  overflow: hidden;
+}
+#schedule-carousel {
+  display: flex;
+  transition: transform 0.3s ease;
+  width: 100%;
+}
+.schedule-period {
+  min-width: 100%;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 60px;
+  gap: 4px;
+  padding-bottom: 10px;
+}
+.time-block {
+  position: relative;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2px;
+}
+.time-title {
+  font-size: 12px;
+}
+.task-icons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2px;
+}
+.task-icons img {
+  width: 30px;
+  height: 30px;
+}
+.task-count {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 10px;
+}
+.schedule-period.morning .time-block {
+  background: linear-gradient(to bottom, #40e0d0, #ffffff);
+}
+.schedule-period.afternoon .time-block {
+  background: linear-gradient(to bottom, #ffa500, #40e0d0);
+}
+.schedule-period.night .time-block {
+  background: linear-gradient(to bottom, #003366, #001a33);
+}
+.schedule-period.dawn .time-block {
+  background: linear-gradient(to bottom, #000000, #000814);
+}
+
 .accept-btn {
   background: #44B816;
 }


### PR DESCRIPTION
## Summary
- Map game aspects to their corresponding images
- Introduce a daily schedule with 15-minute blocks divided into four periods
- Style schedule blocks and enable horizontal swiping between periods

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_68a280c3e49883259018b780637c7b18