### PR TITLE
Add daily schedule view and restore aspect images

### DIFF
--- a/data/aspects.json
+++ b/data/aspects.json
@@ -1,5 +1,6 @@
 {
   "Water": {
+    "image": "aspect1.png",
     "importanceQuestion": "De 1 a 10, qual a importância da sua hidratação diária para o seu bem-estar?",
     "levelQuestion": "Qual o nível atual da sua hidratação diária hoje?",
     "speech": "Comprometo-me a manter meu corpo hidratado, combustível vital para a liderança da minha vida.",
@@ -10,6 +11,7 @@
     ]
   },
   "Nutrition": {
+    "image": "aspect2.png",
     "importanceQuestion": "De 1 a 10, qual a importância de manter uma alimentação equilibrada para sua vida?",
     "levelQuestion": "Qual o nível atual da sua alimentação equilibrada hoje?",
     "speech": "Prometo alimentar meu corpo com equilíbrio para sustentar força e clareza mental.",
@@ -20,6 +22,7 @@
     ]
   },
   "Sleep": {
+    "image": "aspect3.png",
     "importanceQuestion": "De 1 a 10, quão essencial é ter um sono de qualidade para seu desempenho diário?",
     "levelQuestion": "Qual o nível atual da qualidade do seu sono hoje?",
     "speech": "Defendo o sono de qualidade como pilar de energia e decisões acertadas.",
@@ -30,6 +33,7 @@
     ]
   },
   "Hygiene": {
+    "image": "aspect4.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter bons hábitos de higiene para sua saúde?",
     "levelQuestion": "Qual o nível atual dos seus hábitos de higiene hoje?",
     "speech": "Manterei a higiene como escudo contra doenças e base para a confiança.",
@@ -40,6 +44,7 @@
     ]
   },
   "Emocional": {
+    "image": "aspect5.png",
     "importanceQuestion": "De 1 a 10, como você valoriza o autocontrole emocional e a resiliência?",
     "levelQuestion": "Qual o nível atual do seu autocontrole emocional hoje?",
     "speech": "Cultivarei autocontrole e resiliência para governar minha mente com sabedoria.",
@@ -50,6 +55,7 @@
     ]
   },
   "Mindfulness": {
+    "image": "aspect6.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter foco e presença plena no dia a dia?",
     "levelQuestion": "Qual o nível atual do seu foco e presença hoje?",
     "speech": "Manterei foco e presença para honrar cada momento com intenção.",
@@ -60,6 +66,7 @@
     ]
   },
   "Learning": {
+    "image": "aspect7.png",
     "importanceQuestion": "De 1 a 10, como você valoriza aprender coisas novas constantemente?",
     "levelQuestion": "Qual o nível atual do seu aprendizado constante hoje?",
     "speech": "Investirei no aprendizado contínuo como chave para minha evolução.",
@@ -70,6 +77,7 @@
     ]
   },
   "Family": {
+    "image": "aspect8.png",
     "importanceQuestion": "De 1 a 10, quão importante é cuidar dos seus vínculos familiares?",
     "levelQuestion": "Qual o nível atual do cuidado com seus vínculos familiares hoje?",
     "speech": "Preservarei e fortalecerei meus laços familiares como núcleo de apoio.",
@@ -80,6 +88,7 @@
     ]
   },
   "Relationships": {
+    "image": "aspect9.png",
     "importanceQuestion": "De 1 a 10, quão importante é manter relações externas saudáveis?",
     "levelQuestion": "Qual o nível atual das suas relações externas hoje?",
     "speech": "Construirei conexões saudáveis que ampliem minha visão e força.",
@@ -90,6 +99,7 @@
     ]
   },
   "Financial": {
+    "image": "aspect10.png",
     "importanceQuestion": "De 1 a 10, como você valoriza sua segurança e liberdade financeira?",
     "levelQuestion": "Qual o nível atual da sua segurança e liberdade financeira hoje?",
     "speech": "Buscarei estabilidade financeira para garantir minha liberdade de escolha.",
@@ -100,6 +110,7 @@
     ]
   },
   "Purpose": {
+    "image": "aspect11.png",
     "importanceQuestion": "De 1 a 10, quão importante é ter propósito e metas de vida claras?",
     "levelQuestion": "Qual o nível atual de clareza do seu propósito e metas hoje?",
     "speech": "Viverei com propósito e metas claras, guiando cada passo com sentido.",
@@ -110,6 +121,7 @@
     ]
   },
   "Contribution": {
+    "image": "aspect12.png",
     "importanceQuestion": "De 1 a 10, como você valoriza contribuir para o mundo de forma positiva?",
     "levelQuestion": "Qual o nível atual da sua contribuição positiva hoje?",
     "speech": "Contribuirei para um mundo melhor, deixando marcas positivas.",

--- a/index.html
+++ b/index.html
@@ -52,22 +52,28 @@
       </div>
     </section>
     <section id="tasks" class="page">
-      <h1>Tarefas</h1>
-      <div id="tasks-hub">
-        <button id="add-task-btn">Nova tarefa</button>
-        <button id="suggest-task-btn">Ver ideias</button>
+      <div id="tasks-main">
+        <h1>Tarefas</h1>
+        <div id="tasks-hub">
+          <button id="add-task-btn">Nova tarefa</button>
+          <button id="suggest-task-btn">Ver ideias</button>
+        </div>
+        <div id="tasks-pending">
+          <h2>Pendentes</h2>
+          <div class="task-group" id="pending-list"></div>
+        </div>
+        <div id="tasks-completed">
+          <h2>Concluídas</h2>
+          <div class="task-group" id="completed-list"></div>
+        </div>
+        <div id="tasks-overdue">
+          <h2>Atrasadas</h2>
+          <div class="task-group" id="overdue-list"></div>
+        </div>
       </div>
-      <div id="tasks-pending">
-        <h2>Pendentes</h2>
-        <div class="task-group" id="pending-list"></div>
-      </div>
-      <div id="tasks-completed">
-        <h2>Concluídas</h2>
-        <div class="task-group" id="completed-list"></div>
-      </div>
-      <div id="tasks-overdue">
-        <h2>Atrasadas</h2>
-        <div class="task-group" id="overdue-list"></div>
+      <div id="day-schedule">
+        <h2 id="schedule-title"></h2>
+        <div id="schedule-carousel"></div>
       </div>
     </section>
     <section id="laws" class="page">

--- a/js/main.js
+++ b/js/main.js
@@ -180,7 +180,7 @@ function initApp(firstTime) {
     responses = JSON.parse(localStorage.getItem('responses') || '{}');
   }
   buildOptions();
-  initTasks(aspectKeys, tasksData);
+  initTasks(aspectKeys, tasksData, aspectsData);
   initLaws(aspectKeys, lawsData, statsColors);
   initStats(aspectKeys, responses, statsColors);
   initMindset(aspectKeys, mindsetData, statsColors);

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -1,6 +1,9 @@
 let aspectKeys = [];
 let tasksData = [];
 let editingTaskIndex = null;
+let aspectsMap = {};
+let scheduleIndex = 0;
+let scheduleSwipeInitialized = false;
 
 const addTaskBtn = document.getElementById('add-task-btn');
 const suggestTaskBtn = document.getElementById('suggest-task-btn');
@@ -13,17 +16,28 @@ const taskTypeInput = document.getElementById('task-type');
 const saveTaskBtn = document.getElementById('save-task');
 const cancelTaskBtn = document.getElementById('cancel-task');
 const completeTaskBtn = document.getElementById('complete-task');
+const scheduleTitle = document.getElementById('schedule-title');
+const scheduleCarousel = document.getElementById('schedule-carousel');
+const tasksSection = document.getElementById('tasks');
+let scheduleVisible = false;
+let swipeStartY = 0;
 
-export function initTasks(keys, data) {
+export function initTasks(keys, data, aspects) {
   aspectKeys = keys;
   tasksData = data;
+  aspectsMap = aspects;
   addTaskBtn.addEventListener('click', () => openTaskModal());
   suggestTaskBtn.addEventListener('click', suggestTask);
   saveTaskBtn.addEventListener('click', saveTask);
   cancelTaskBtn.addEventListener('click', closeTaskModal);
   completeTaskBtn.addEventListener('click', completeTask);
   buildTasks();
-  setInterval(buildTasks, 60000);
+  buildSchedule();
+  setInterval(() => {
+    buildTasks();
+    buildSchedule();
+  }, 60000);
+  initScheduleToggle();
 }
 
 function buildTasks() {
@@ -78,6 +92,122 @@ function buildTasks() {
   if (!tasks.length) {
     pending.textContent = 'Sem tarefas ainda';
   }
+}
+
+function buildSchedule() {
+  if (!scheduleCarousel || !scheduleTitle) return;
+  const now = new Date();
+  scheduleTitle.textContent = now.toLocaleString('pt-BR');
+  const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+  const todayTasks = tasks.filter(t => {
+    const d = new Date(t.startTime);
+    return d.toDateString() === now.toDateString();
+  });
+  const periods = [
+    { name: 'morning', start: 6 },
+    { name: 'afternoon', start: 12 },
+    { name: 'night', start: 18 },
+    { name: 'dawn', start: 0 }
+  ];
+  scheduleCarousel.innerHTML = '';
+  periods.forEach(p => {
+    const period = document.createElement('div');
+    period.className = `schedule-period ${p.name}`;
+    const start = p.start;
+    for (let i = 0; i < 24; i++) {
+      const block = document.createElement('div');
+      block.className = 'time-block';
+      const minutes = (start * 60) + i * 15;
+      const h = Math.floor(minutes / 60) % 24;
+      const m = minutes % 60;
+      const label = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+      const title = document.createElement('div');
+      title.className = 'time-title';
+      title.textContent = label;
+      block.appendChild(title);
+      const icons = document.createElement('div');
+      icons.className = 'task-icons';
+      const matching = todayTasks.filter((t, idx) => {
+        const d = new Date(t.startTime);
+        return d.getHours() === h && d.getMinutes() === m;
+      });
+      const count = document.createElement('span');
+      count.className = 'task-count';
+      count.textContent = matching.length;
+      block.appendChild(count);
+      matching.slice(0,5).forEach(t => {
+        const img = document.createElement('img');
+        img.src = aspectsMap[t.aspect]?.image || '';
+        img.alt = t.aspect;
+        img.width = 30;
+        img.height = 30;
+        const idx = tasks.indexOf(t);
+        img.addEventListener('click', () => openTaskModal(idx));
+        icons.appendChild(img);
+      });
+      block.appendChild(icons);
+      period.appendChild(block);
+    }
+    scheduleCarousel.appendChild(period);
+  });
+  scheduleIndex = getCurrentPeriodIndex(now.getHours());
+  scheduleCarousel.style.transform = `translateX(-${scheduleIndex * 100}%)`;
+  initScheduleSwipe();
+}
+
+function getCurrentPeriodIndex(hour) {
+  if (hour >= 6 && hour < 12) return 0;
+  if (hour >= 12 && hour < 18) return 1;
+  if (hour >= 18 && hour < 24) return 2;
+  return 3;
+}
+
+function initScheduleSwipe() {
+  if (scheduleSwipeInitialized) return;
+  scheduleSwipeInitialized = true;
+  let startX = 0;
+  scheduleCarousel.addEventListener('touchstart', e => {
+    startX = e.touches[0].clientX;
+  });
+  scheduleCarousel.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - startX;
+    if (dx > 50) {
+      scheduleIndex = (scheduleIndex - 1 + 4) % 4;
+    } else if (dx < -50) {
+      scheduleIndex = (scheduleIndex + 1) % 4;
+    }
+    scheduleCarousel.style.transform = `translateX(-${scheduleIndex * 100}%)`;
+  });
+}
+
+function initScheduleToggle() {
+  if (!tasksSection) return;
+  tasksSection.addEventListener('touchstart', e => {
+    swipeStartY = e.touches[0].clientY;
+  });
+  tasksSection.addEventListener('touchend', e => {
+    const dy = e.changedTouches[0].clientY - swipeStartY;
+    if (!scheduleVisible && dy < -50) {
+      tasksSection.classList.add('show-schedule');
+      scheduleVisible = true;
+    } else if (scheduleVisible && dy > 50) {
+      tasksSection.classList.remove('show-schedule');
+      scheduleVisible = false;
+    }
+  });
+  tasksSection.addEventListener('mousedown', e => {
+    swipeStartY = e.clientY;
+  });
+  tasksSection.addEventListener('mouseup', e => {
+    const dy = e.clientY - swipeStartY;
+    if (!scheduleVisible && dy < -50) {
+      tasksSection.classList.add('show-schedule');
+      scheduleVisible = true;
+    } else if (scheduleVisible && dy > 50) {
+      tasksSection.classList.remove('show-schedule');
+      scheduleVisible = false;
+    }
+  });
 }
 
 function openTaskModal(index = null, prefill = null) {
@@ -141,6 +271,7 @@ function suggestTask() {
   });
   localStorage.setItem('tasks', JSON.stringify(tasks));
   buildTasks();
+  buildSchedule();
 }
 
 function closeTaskModal() {
@@ -178,6 +309,7 @@ function saveTask() {
   localStorage.setItem('tasks', JSON.stringify(tasks));
   closeTaskModal();
   buildTasks();
+  buildSchedule();
 }
 
 function completeTask() {
@@ -187,5 +319,6 @@ function completeTask() {
   localStorage.setItem('tasks', JSON.stringify(tasks));
   closeTaskModal();
   buildTasks();
+  buildSchedule();
 }
 

--- a/styles.css
+++ b/styles.css
@@ -272,8 +272,41 @@ li:hover { transform: scale(1.02); }
   margin-bottom: 20px;
 }
 
+
 .task-group {
   margin-bottom: 20px;
+}
+
+#tasks {
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
+}
+
+#tasks-main,
+#day-schedule {
+  width: 100%;
+  height: 100%;
+  transition: transform 0.3s ease;
+}
+
+#tasks-main {
+  overflow-y: auto;
+}
+
+#day-schedule {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  overflow-y: auto;
+}
+
+#tasks.show-schedule #tasks-main {
+  transform: translateY(-100%);
+}
+
+#tasks.show-schedule #day-schedule {
+  transform: translateY(-100%);
 }
 
 #laws-hub {
@@ -413,6 +446,65 @@ li:hover { transform: scale(1.02); }
   margin-bottom: 10px;
   border-radius: 8px;
   color: #fff;
+}
+
+#schedule-carousel {
+  display: flex;
+  transition: transform 0.3s ease;
+  width: 100%;
+}
+
+.schedule-period {
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 0;
+}
+
+.time-block {
+  position: relative;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2px;
+  width: 100%;
+  height: 60px;
+}
+.time-title {
+  font-size: 12px;
+}
+.task-icons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2px;
+}
+.task-icons img {
+  width: 30px;
+  height: 30px;
+}
+.task-count {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 10px;
+}
+.schedule-period.morning .time-block {
+  background: linear-gradient(to bottom, #40e0d0, #ffffff);
+  color: #40e0d0;
+}
+.schedule-period.afternoon .time-block {
+  background: linear-gradient(to bottom, #ffa500, #40e0d0);
+  color: #40e0d0;
+}
+.schedule-period.night .time-block {
+  background: linear-gradient(to bottom, #003366, #001a33);
+}
+.schedule-period.dawn .time-block {
+  background: linear-gradient(to bottom, #000000, #000814);
 }
 
 .accept-btn {


### PR DESCRIPTION
## Summary
- Map game aspects to their corresponding images
- Introduce a daily schedule with 15-minute blocks divided into four periods
- Allow swiping up in Tasks to reveal the schedule tab with full-width blocks and turquoise text on light backgrounds

## Testing
- `node --check js/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_68a280c3e49883259018b780637c7b18