### PR TITLE
Use centered icons for section headers and rework task schedule controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       </div>
     </section>
     <section id="tasks" class="page">
-      <h1>Tarefas</h1>
+      <img src="acoes.png" alt="Tarefas" class="icone-central" />
       <div id="tasks-tabs">
         <div id="tasks-content">
           <div id="tasks-hub">
@@ -79,7 +79,7 @@
       </div>
     </section>
     <section id="laws" class="page">
-      <h1>Leis</h1>
+      <img src="leis.png" alt="Leis" class="icone-central" />
       <div id="laws-hub">
         <button id="add-law-btn">Nova lei</button>
         <button id="suggest-law-btn">Ver ideias</button>
@@ -87,11 +87,11 @@
       <div id="laws-list"></div>
     </section>
     <section id="stats" class="page">
-      <h1>Stats</h1>
+      <img src="estatisticas.png" alt="Estatísticas" class="icone-central" />
       <div id="stats-content"></div>
     </section>
     <section id="mindset" class="page">
-      <h1>Mindset</h1>
+      <img src="mindset.png" alt="Mindset" class="icone-central" />
       <div id="mindset-hub">
         <button id="add-mindset-btn">Criar mindset</button>
         <button id="suggest-mindset-btn">Ver ideias</button>
@@ -99,11 +99,11 @@
       <div id="mindset-content"></div>
     </section>
     <section id="history" class="page">
-      <h1>Histórico</h1>
+      <img src="historico.png" alt="Histórico" class="icone-central" />
       <p>Em desenvolvimento...</p>
     </section>
     <section id="options" class="page">
-      <h1>Opções</h1>
+      <img src="constituicao.png" alt="Opções" class="icone-central" />
       <div id="options-content"></div>
     </section>
   </main>

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -2,7 +2,7 @@ let aspectKeys = [];
 let tasksData = [];
 let editingTaskIndex = null;
 let aspectsMap = {};
-let touchStartY = 0;
+let touchStartX = 0;
 
 const addTaskBtn = document.getElementById('add-task-btn');
 const suggestTaskBtn = document.getElementById('suggest-task-btn');
@@ -29,16 +29,38 @@ export function initTasks(keys, data, aspects) {
   cancelTaskBtn.addEventListener('click', closeTaskModal);
   completeTaskBtn.addEventListener('click', completeTask);
   tasksSection.addEventListener('touchstart', e => {
-    touchStartY = e.touches[0].clientY;
+    touchStartX = e.touches[0].clientX;
   });
   tasksSection.addEventListener('touchend', e => {
-    const dy = e.changedTouches[0].clientY - touchStartY;
-    if (!tasksSection.classList.contains('show-schedule') && dy < -50) {
+    const dx = e.changedTouches[0].clientX - touchStartX;
+    if (!tasksSection.classList.contains('show-schedule') && dx < -50) {
       tasksSection.classList.add('show-schedule');
-    } else if (tasksSection.classList.contains('show-schedule') && dy > 50) {
+    } else if (tasksSection.classList.contains('show-schedule') && dx > 50) {
       tasksSection.classList.remove('show-schedule');
     }
   });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowUp') {
+      tasksSection.classList.add('show-schedule');
+    } else if (e.key === 'ArrowDown') {
+      tasksSection.classList.remove('show-schedule');
+    }
+  });
+  const centralIcon = tasksSection.querySelector('.icone-central');
+  if (centralIcon) {
+    let pressTimer;
+    const startPress = () => {
+      pressTimer = setTimeout(() => {
+        tasksSection.classList.toggle('show-schedule');
+      }, 1000);
+    };
+    const cancelPress = () => clearTimeout(pressTimer);
+    centralIcon.addEventListener('mousedown', startPress);
+    centralIcon.addEventListener('touchstart', startPress);
+    centralIcon.addEventListener('mouseup', cancelPress);
+    centralIcon.addEventListener('mouseleave', cancelPress);
+    centralIcon.addEventListener('touchend', cancelPress);
+  }
   buildTasks();
   buildSchedule();
   setInterval(() => {

--- a/styles.css
+++ b/styles.css
@@ -230,6 +230,13 @@ li:hover { transform: scale(1.02); }
   margin-top: 10px;
 }
 
+.icone-central {
+  display: block;
+  margin: 0 auto 20px;
+  width: 150px;
+  height: 150px;
+}
+
 .page {
   display: none;
   padding: 80px 30px 20px;
@@ -451,6 +458,7 @@ li:hover { transform: scale(1.02); }
   padding: 2px;
   width: 100%;
   color: #40e0d0;
+  height: 150px;
 }
 .time-title {
   font-size: 12px;


### PR DESCRIPTION
## Summary
- Replace section headers with centered PNG icons referenced as `icone-central`.
- Enable horizontal swipe, arrow key, and long-press on the central icon to toggle the 15‑minute schedule view.
- Increase vertical size of schedule time blocks for clearer viewing.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2887d7a8c8325a775ac8589555451