### PR TITLE
Revamp tasks with calendar boxtime view and mobile tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,9 +72,9 @@
             <div class="task-group" id="overdue-list"></div>
           </div>
         </div>
-        <div id="day-schedule">
-          <h2 id="schedule-title"></h2>
-          <div id="schedule-list"></div>
+        <div id="calendar">
+          <h2 id="calendar-title"></h2>
+          <div id="calendar-list"></div>
         </div>
       </div>
     </section>

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -15,8 +15,8 @@ const taskTypeInput = document.getElementById('task-type');
 const saveTaskBtn = document.getElementById('save-task');
 const cancelTaskBtn = document.getElementById('cancel-task');
 const completeTaskBtn = document.getElementById('complete-task');
-const scheduleTitle = document.getElementById('schedule-title');
-const scheduleList = document.getElementById('schedule-list');
+const calendarTitle = document.getElementById('calendar-title');
+const calendarList = document.getElementById('calendar-list');
 const tasksSection = document.getElementById('tasks');
 
 export function initTasks(keys, data, aspects) {
@@ -33,17 +33,17 @@ export function initTasks(keys, data, aspects) {
   });
   tasksSection.addEventListener('touchend', e => {
     const dx = e.changedTouches[0].clientX - touchStartX;
-    if (!tasksSection.classList.contains('show-schedule') && dx < -50) {
-      tasksSection.classList.add('show-schedule');
-    } else if (tasksSection.classList.contains('show-schedule') && dx > 50) {
-      tasksSection.classList.remove('show-schedule');
+    if (!tasksSection.classList.contains('show-calendar') && dx < -50) {
+      tasksSection.classList.add('show-calendar');
+    } else if (tasksSection.classList.contains('show-calendar') && dx > 50) {
+      tasksSection.classList.remove('show-calendar');
     }
   });
   document.addEventListener('keydown', e => {
     if (e.key === 'ArrowUp') {
-      tasksSection.classList.add('show-schedule');
+      tasksSection.classList.add('show-calendar');
     } else if (e.key === 'ArrowDown') {
-      tasksSection.classList.remove('show-schedule');
+      tasksSection.classList.remove('show-calendar');
     }
   });
   const centralIcon = tasksSection.querySelector('.icone-central');
@@ -51,7 +51,7 @@ export function initTasks(keys, data, aspects) {
     let pressTimer;
     const startPress = () => {
       pressTimer = setTimeout(() => {
-        tasksSection.classList.toggle('show-schedule');
+        tasksSection.classList.toggle('show-calendar');
       }, 1000);
     };
     const cancelPress = () => clearTimeout(pressTimer);
@@ -62,10 +62,10 @@ export function initTasks(keys, data, aspects) {
     centralIcon.addEventListener('touchend', cancelPress);
   }
   buildTasks();
-  buildSchedule();
+  buildCalendar();
   setInterval(() => {
     buildTasks();
-    buildSchedule();
+    buildCalendar();
   }, 60000);
 }
 
@@ -123,37 +123,37 @@ function buildTasks() {
   }
 }
 
-function buildSchedule() {
-  if (!scheduleList || !scheduleTitle) return;
+function buildCalendar() {
+  if (!calendarList || !calendarTitle) return;
   const now = new Date();
-  scheduleTitle.textContent = now.toLocaleString('pt-BR');
+  calendarTitle.textContent = now.toLocaleString('pt-BR');
   const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
   const todayTasks = tasks.filter(t => {
     const d = new Date(t.startTime);
     return d.toDateString() === now.toDateString();
   });
-  scheduleList.innerHTML = '';
+  calendarList.innerHTML = '';
   for (let minutes = 0; minutes < 24 * 60; minutes += 15) {
     const h = Math.floor(minutes / 60);
     const m = minutes % 60;
     const label = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-    const block = document.createElement('div');
-    block.className = `time-block ${getPeriodClass(h)}`;
-    const title = document.createElement('div');
-    title.className = 'time-title';
-    title.textContent = label;
-    block.appendChild(title);
+    const boxtime = document.createElement('div');
+    boxtime.className = 'boxtime';
+    const blockTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m);
+    if (blockTime < now) {
+      boxtime.classList.add('past');
+    }
+    const timeDiv = document.createElement('div');
+    timeDiv.className = 'boxtime-time';
+    timeDiv.textContent = label;
+    boxtime.appendChild(timeDiv);
     const icons = document.createElement('div');
-    icons.className = 'task-icons';
+    icons.className = 'boxtime-icons';
     const matching = todayTasks.filter(t => {
       const d = new Date(t.startTime);
-      return d.getHours() === h && d.getMinutes() === m;
+      return d.getHours() === h && Math.floor(d.getMinutes() / 15) * 15 === m;
     });
-    const count = document.createElement('span');
-    count.className = 'task-count';
-    count.textContent = matching.length;
-    block.appendChild(count);
-    matching.slice(0, 5).forEach(t => {
+    matching.slice(0, 4).forEach(t => {
       const img = document.createElement('img');
       img.src = aspectsMap[t.aspect]?.image || '';
       img.alt = t.aspect;
@@ -163,16 +163,9 @@ function buildSchedule() {
       img.addEventListener('click', () => openTaskModal(idx));
       icons.appendChild(img);
     });
-    block.appendChild(icons);
-    scheduleList.appendChild(block);
+    boxtime.appendChild(icons);
+    calendarList.appendChild(boxtime);
   }
-}
-
-function getPeriodClass(hour) {
-  if (hour >= 6 && hour < 12) return 'morning';
-  if (hour >= 12 && hour < 18) return 'afternoon';
-  if (hour >= 18 && hour < 24) return 'night';
-  return 'dawn';
 }
 
 function openTaskModal(index = null, prefill = null) {
@@ -236,7 +229,7 @@ function suggestTask() {
   });
   localStorage.setItem('tasks', JSON.stringify(tasks));
   buildTasks();
-  buildSchedule();
+  buildCalendar();
 }
 
 function closeTaskModal() {
@@ -274,7 +267,7 @@ function saveTask() {
   localStorage.setItem('tasks', JSON.stringify(tasks));
   closeTaskModal();
   buildTasks();
-  buildSchedule();
+  buildCalendar();
 }
 
 function completeTask() {
@@ -284,6 +277,6 @@ function completeTask() {
   localStorage.setItem('tasks', JSON.stringify(tasks));
   closeTaskModal();
   buildTasks();
-  buildSchedule();
+  buildCalendar();
 }
 

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,12 @@
   font-weight: 700;
   font-style: normal;
 }
+@font-face {
+  font-family: 'Lato';
+  src: url('Fonts/Lato-Light.ttf') format('truetype');
+  font-weight: 300;
+  font-style: normal;
+}
 
 .dark {
   --bg-color: #222;
@@ -26,6 +32,7 @@ body {
   background: var(--bg-color);
   color: var(--text-color);
   font-family: 'Lato', sans-serif;
+  font-weight: 300;
   margin: 0;
   user-select: none;
   -webkit-user-select: none;
@@ -427,69 +434,51 @@ li:hover { transform: scale(1.02); }
   overflow: hidden;
 }
 #tasks-content,
-#day-schedule {
+#calendar {
   width: 100%;
   transition: transform 0.3s ease;
 }
-#day-schedule {
+#calendar {
   position: absolute;
   top: 100%;
   left: 0;
 }
-#tasks.show-schedule #tasks-content {
+#tasks.show-calendar #tasks-content {
   transform: translateY(-100%);
 }
-#tasks.show-schedule #day-schedule {
+#tasks.show-calendar #calendar {
   transform: translateY(-100%);
 }
-#schedule-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding-bottom: 10px;
-}
-.time-block {
-  position: relative;
-  border-radius: 4px;
+#calendar-list {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  padding: 2px;
-  width: 100%;
-  color: #40e0d0;
-  height: 150px;
+  gap: 15px;
+  padding: 15px 15px 10px;
 }
-.time-title {
-  font-size: 12px;
-}
-.task-icons {
+.boxtime {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 2px;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 500px;
 }
-.task-icons img {
+.boxtime-time {
+  font-size: 32px;
+  color: rgba(255, 255, 255, 0.75);
+}
+.boxtime-icons {
+  display: grid;
+  grid-template-columns: repeat(2, 30px);
+  grid-template-rows: repeat(2, 30px);
+  gap: 5px;
+}
+.boxtime-icons img {
   width: 30px;
   height: 30px;
 }
-.task-count {
-  position: absolute;
-  top: 2px;
-  right: 4px;
-  font-size: 10px;
-}
-.time-block.morning {
-  background: linear-gradient(to bottom, #40e0d0, #ffffff);
-}
-.time-block.afternoon {
-  background: linear-gradient(to bottom, #ffa500, #40e0d0);
-}
-.time-block.night {
-  background: linear-gradient(to bottom, #003366, #001a33);
-}
-.time-block.dawn {
-  background: linear-gradient(to bottom, #000000, #000814);
+.boxtime.past {
+  opacity: 0.4;
 }
 
 .accept-btn {
@@ -517,6 +506,7 @@ li:hover { transform: scale(1.02); }
   h2 { font-size: 14px; }
   p, span, label, input, button, li { font-size: 11px; }
   button { font-size: 10px; padding: 7px 14px; }
+  .icone-central { display: none; }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
   .menu-item img,


### PR DESCRIPTION
## Summary
- Hide central icon on mobile and introduce Lato Light styling
- Replace day schedule with calendar view using 15‑minute boxtimes
- Map tasks to their corresponding boxtime with icons and past-time fade

## Testing
- `node --check js/tasks.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a28ce2cd9083259a00af7aa51ab9c0