### PR TITLE
Adjust calendar tasks layout and navigation

### DIFF
--- a/js/tasks.js
+++ b/js/tasks.js
@@ -46,6 +46,10 @@ export function initTasks(keys, data, aspects) {
       tasksSection.classList.add('show-calendar');
     } else if (e.key === 'ArrowDown') {
       tasksSection.classList.remove('show-calendar');
+    } else if (e.key === 'ArrowLeft') {
+      changePeriod(-1);
+    } else if (e.key === 'ArrowRight') {
+      changePeriod(1);
     }
   });
   const centralIcon = tasksSection.querySelector('.icone-central');
@@ -154,7 +158,7 @@ function buildCalendar() {
   const now = new Date();
   const start = calendarStart;
   const periodInfo = getPeriodInfo(start.getHours());
-  calendarTitle.textContent = `${formatDate(start)} + ${periodInfo.label}`;
+  calendarTitle.textContent = `${formatDate(start)} (${periodInfo.label})`;
   const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
   const periodEnd = new Date(start.getTime() + 6 * 60 * 60 * 1000);
   const periodTasks = tasks.filter(t => {

--- a/styles.css
+++ b/styles.css
@@ -442,6 +442,9 @@ li:hover { transform: scale(1.02); }
   position: absolute;
   top: 100%;
   left: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 #tasks.show-calendar #tasks-content {
   transform: translateY(-100%);
@@ -449,20 +452,32 @@ li:hover { transform: scale(1.02); }
 #tasks.show-calendar #calendar {
   transform: translateY(-100%);
 }
+#calendar-title {
+  height: 60px;
+  width: 100%;
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Lato', sans-serif;
+  font-size: 20px;
+}
 #calendar-list {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 15px;
   padding: 15px 15px 10px;
+  flex: 1;
+  overflow-y: auto;
 }
 .boxtime {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   width: 100%;
-  max-width: 500px;
-  padding: 5px;
+  max-width: 520px;
+  padding: 5px 15px;
   border-radius: 8px;
 }
 .boxtime-time {
@@ -470,10 +485,10 @@ li:hover { transform: scale(1.02); }
   color: rgba(255, 255, 255, 0.75);
 }
 .boxtime-icons {
-  display: grid;
-  grid-template-columns: repeat(2, 30px);
-  grid-template-rows: repeat(2, 30px);
+  display: flex;
+  align-items: center;
   gap: 5px;
+  margin-left: 20px;
 }
 .boxtime-icons img {
   width: 30px;


### PR DESCRIPTION
## Summary
- Allow keyboard left/right arrows to navigate calendar periods
- Add scrollable calendar list with styled title bar
- Align task icons in a horizontal row and widen time boxes

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a299f83ca48325beaae944caed645b