### PR TITLE
Simplify onboarding and refine mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,12 +43,12 @@
     <div id="menu-carousel" class="menu-carousel"></div>
     <section id="menu" class="page active">
       <div class="menu-grid">
-        <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /><span>Tarefas</span></div>
-        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /><span>Leis</span></div>
-        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /><span>Estatísticas</span></div>
-        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /><span>Mindset</span></div>
-        <div class="menu-item" data-page="options"><img src="constituicao.png" alt="Opções" /><span>Opções</span></div>
-        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /><span>Histórico</span></div>
+        <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /></div>
+        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /></div>
+        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /></div>
+        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /></div>
+        <div class="menu-item" data-page="options"><img src="constituicao.png" alt="Opções" /></div>
+        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /></div>
       </div>
     </section>
     <section id="tasks" class="page">

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,6 @@ let tasksData = [];
 let lawsData = [];
 let mindsetData = [];
 let currentIndex = 0;
-let currentStep = 0; // 0 importance, 1 level
 let responses = JSON.parse(localStorage.getItem('responses') || '{}');
 let previousLogin = 0;
 
@@ -118,24 +117,14 @@ slider.addEventListener('input', updateFeedback);
 
 document.getElementById('next-btn').addEventListener('click', () => {
   const key = aspectKeys[currentIndex];
-  if (!responses[key]) responses[key] = { importance: 0, level: 50 };
-  if (currentStep === 0) {
-    responses[key].importance = Number(slider.value);
-    currentStep = 1;
-    slider.value = responses[key].level || 50;
-    updateFeedback();
+  responses[key] = { importance: Number(slider.value), level: 50 };
+  currentIndex++;
+  if (currentIndex < aspectKeys.length) {
     showQuestion();
   } else {
-    responses[key].level = Number(slider.value);
-    currentStep = 0;
-    currentIndex++;
-    if (currentIndex < aspectKeys.length) {
-      showQuestion();
-    } else {
-      document.getElementById('question-screen').classList.add('hidden');
-      document.getElementById('oath-text').textContent = buildOath();
-      document.getElementById('name-screen').classList.remove('hidden');
-    }
+    document.getElementById('question-screen').classList.add('hidden');
+    document.getElementById('oath-text').textContent = buildOath();
+    document.getElementById('name-screen').classList.remove('hidden');
   }
 });
 
@@ -179,6 +168,10 @@ function initApp(firstTime) {
   } else {
     responses = JSON.parse(localStorage.getItem('responses') || '{}');
   }
+  const savedGradient = JSON.parse(localStorage.getItem('bgGradient') || 'null');
+  if (savedGradient) {
+    document.body.style.background = `linear-gradient(${savedGradient[0]}, ${savedGradient[1]})`;
+  }
   buildOptions();
   initTasks(aspectKeys, tasksData, aspectsData);
   initLaws(aspectKeys, lawsData, statsColors);
@@ -197,6 +190,32 @@ function initApp(firstTime) {
 function buildOptions() {
   const container = document.getElementById('options-content');
   container.innerHTML = '';
+  const themeTitle = document.createElement('h2');
+  themeTitle.textContent = 'Cores de fundo';
+  container.appendChild(themeTitle);
+  const color1 = document.createElement('input');
+  color1.type = 'color';
+  const color2 = document.createElement('input');
+  color2.type = 'color';
+  const applyBtn = document.createElement('button');
+  applyBtn.textContent = 'Aplicar';
+  const saved = JSON.parse(localStorage.getItem('bgGradient') || 'null');
+  if (saved) {
+    color1.value = saved[0];
+    color2.value = saved[1];
+  } else {
+    color1.value = '#000000';
+    color2.value = '#222222';
+  }
+  applyBtn.addEventListener('click', () => {
+    const c1 = color1.value;
+    const c2 = color2.value;
+    document.body.style.background = `linear-gradient(${c1}, ${c2})`;
+    localStorage.setItem('bgGradient', JSON.stringify([c1, c2]));
+  });
+  container.appendChild(color1);
+  container.appendChild(color2);
+  container.appendChild(applyBtn);
   const categories = [
     { title: 'Princípios fundamentais', filter: v => v === 10 },
     { title: 'Pilares de uma vida equilibrada', filter: v => v >= 8 && v <= 9 },
@@ -252,15 +271,12 @@ function initCarousel() {
   ];
   let idx = 0;
   const img = document.createElement('img');
-  const span = document.createElement('span');
   menuCarousel.appendChild(img);
-  menuCarousel.appendChild(span);
 
   function render() {
     const item = items[idx];
     img.src = item.img;
     img.alt = item.label;
-    span.textContent = item.label;
     showPage(item.page);
   }
 

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -2,7 +2,6 @@ let aspectKeys = [];
 let tasksData = [];
 let editingTaskIndex = null;
 let aspectsMap = {};
-let touchStartX = 0;
 let calendarStart = getCurrentPeriodStart(new Date());
 let titleTouchX = 0;
 
@@ -30,17 +29,6 @@ export function initTasks(keys, data, aspects) {
   saveTaskBtn.addEventListener('click', saveTask);
   cancelTaskBtn.addEventListener('click', closeTaskModal);
   completeTaskBtn.addEventListener('click', completeTask);
-  tasksSection.addEventListener('touchstart', e => {
-    touchStartX = e.touches[0].clientX;
-  });
-  tasksSection.addEventListener('touchend', e => {
-    const dx = e.changedTouches[0].clientX - touchStartX;
-    if (!tasksSection.classList.contains('show-calendar') && dx < -50) {
-      tasksSection.classList.add('show-calendar');
-    } else if (tasksSection.classList.contains('show-calendar') && dx > 50) {
-      tasksSection.classList.remove('show-calendar');
-    }
-  });
   document.addEventListener('keydown', e => {
     if (e.key === 'ArrowUp') {
       tasksSection.classList.add('show-calendar');
@@ -56,9 +44,10 @@ export function initTasks(keys, data, aspects) {
   if (centralIcon) {
     let pressTimer;
     const startPress = () => {
+      const delay = tasksSection.classList.contains('show-calendar') ? 600 : 400;
       pressTimer = setTimeout(() => {
         tasksSection.classList.toggle('show-calendar');
-      }, 1000);
+      }, delay);
     };
     const cancelPress = () => clearTimeout(pressTimer);
     centralIcon.addEventListener('mousedown', startPress);

--- a/styles.css
+++ b/styles.css
@@ -103,8 +103,13 @@ select {
   }
 }
 
-.slider-container { margin: 20px 0; }
-#slider { width: 300px; }
+.slider-container {
+  width: calc(100% - 30px);
+  margin: 20px 15px;
+}
+#slider {
+  width: 100%;
+}
 
 .progress-container {
   width: 100%;
@@ -186,6 +191,9 @@ li:hover { transform: scale(1.02); }
   font-size: 20px;
   text-align: center;
 }
+#slider-feedback {
+  color: #fff;
+}
 
 .menu-carousel {
   display: none;
@@ -201,9 +209,6 @@ li:hover { transform: scale(1.02); }
   transition: transform 0.3s ease;
 }
 
-.menu-carousel span {
-  margin-top: 10px;
-}
 
 .menu-grid {
   display: grid;
@@ -233,9 +238,6 @@ li:hover { transform: scale(1.02); }
   transform: scale(1.05);
 }
 
-.menu-item span {
-  margin-top: 10px;
-}
 
 .icone-central {
   display: block;
@@ -535,15 +537,15 @@ li:hover { transform: scale(1.02); }
   h2 { font-size: 14px; }
   p, span, label, input, button, li { font-size: 11px; }
   button { font-size: 10px; padding: 7px 14px; }
-  .icone-central { display: none; }
+  .icone-central { width: 105px; height: 105px; }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
-  .menu-item img,
-  .menu-carousel img { width: 105px; height: 105px; }
+  .menu-item img { width: 105px; height: 105px; }
+  .menu-carousel img { width: 105px; height: 105px; margin-top: 70px; }
   #main-header { height: 42px; }
   .header-container { padding: 7px 30px; }
   .header-logo { height: 28px; }
-  #slider, #stats-slider { width: 210px; }
+  #stats-slider { width: 210px; }
   .progress-container { height: 6px; }
   #progress-bar { border-radius: 3px; }
   .menu-grid { display: none; }


### PR DESCRIPTION
## Summary
- Remove menu icon labels and shift mobile carousel icon downward for clearer navigation
- Ask only for aspect relevance with full-width slider and white feedback
- Add background gradient selectors in constitution options and support long-press calendar toggle

## Testing
- `node --check js/main.js`
- `node --check js/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2a10fa5c08325aec25efe78466470