### PR TITLE
Improve mobile navigation and color customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <div id="tasks-content">
           <div id="tasks-hub">
             <button id="add-task-btn">Nova tarefa</button>
-            <button id="suggest-task-btn">Ver ideias</button>
+            <button id="suggest-task-btn" class="suggest-btn">Ver ideias</button>
           </div>
           <div id="tasks-pending">
             <h2>Pendentes</h2>
@@ -82,7 +82,7 @@
       <img src="leis.png" alt="Leis" class="icone-central" />
       <div id="laws-hub">
         <button id="add-law-btn">Nova lei</button>
-        <button id="suggest-law-btn">Ver ideias</button>
+        <button id="suggest-law-btn" class="suggest-btn">Ver ideias</button>
       </div>
       <div id="laws-list"></div>
     </section>
@@ -94,7 +94,7 @@
       <img src="mindset.png" alt="Mindset" class="icone-central" />
       <div id="mindset-hub">
         <button id="add-mindset-btn">Criar mindset</button>
-        <button id="suggest-mindset-btn">Ver ideias</button>
+        <button id="suggest-mindset-btn" class="suggest-btn">Ver ideias</button>
       </div>
       <div id="mindset-content"></div>
     </section>

--- a/js/main.js
+++ b/js/main.js
@@ -26,6 +26,10 @@ const statsColors = {
   Purpose: ['#7e57c2', '#9575cd'],
   Contribution: ['#ffffff', '#f5f5f5']
 };
+const savedAspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');
+Object.keys(savedAspectColors).forEach(k => {
+  statsColors[k] = [savedAspectColors[k], savedAspectColors[k]];
+});
 
 // Prevent copying, context menu, and zoom interactions
 document.addEventListener('contextmenu', e => e.preventDefault());
@@ -216,6 +220,27 @@ function buildOptions() {
   container.appendChild(color1);
   container.appendChild(color2);
   container.appendChild(applyBtn);
+  const paletteTitle = document.createElement('h2');
+  paletteTitle.textContent = 'Cores dos aspectos';
+  container.appendChild(paletteTitle);
+  const aspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');
+  aspectKeys.forEach(k => {
+    const label = document.createElement('label');
+    label.textContent = k;
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = aspectColors[k] || statsColors[k][0];
+    input.addEventListener('input', () => {
+      aspectColors[k] = input.value;
+      localStorage.setItem('aspectColors', JSON.stringify(aspectColors));
+    });
+    label.appendChild(input);
+    container.appendChild(label);
+  });
+  const applyColors = document.createElement('button');
+  applyColors.textContent = 'Aplicar cores';
+  applyColors.addEventListener('click', () => location.reload());
+  container.appendChild(applyColors);
   const categories = [
     { title: 'Princípios fundamentais', filter: v => v === 10 },
     { title: 'Pilares de uma vida equilibrada', filter: v => v >= 8 && v <= 9 },

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -30,32 +30,36 @@ export function initTasks(keys, data, aspects) {
   cancelTaskBtn.addEventListener('click', closeTaskModal);
   completeTaskBtn.addEventListener('click', completeTask);
   document.addEventListener('keydown', e => {
-    if (e.key === 'ArrowUp') {
-      tasksSection.classList.add('show-calendar');
-    } else if (e.key === 'ArrowDown') {
-      tasksSection.classList.remove('show-calendar');
-    } else if (e.key === 'ArrowLeft') {
+    if (e.key === 'ArrowLeft') {
       changePeriod(-1);
     } else if (e.key === 'ArrowRight') {
       changePeriod(1);
     }
   });
-  const centralIcon = tasksSection.querySelector('.icone-central');
-  if (centralIcon) {
-    let pressTimer;
-    const startPress = () => {
-      const delay = tasksSection.classList.contains('show-calendar') ? 600 : 400;
-      pressTimer = setTimeout(() => {
-        tasksSection.classList.toggle('show-calendar');
-      }, delay);
-    };
-    const cancelPress = () => clearTimeout(pressTimer);
-    centralIcon.addEventListener('mousedown', startPress);
-    centralIcon.addEventListener('touchstart', startPress);
-    centralIcon.addEventListener('mouseup', cancelPress);
-    centralIcon.addEventListener('mouseleave', cancelPress);
-    centralIcon.addEventListener('touchend', cancelPress);
-  }
+  let touchStartX = 0;
+  tasksSection.addEventListener('touchstart', e => {
+    touchStartX = e.touches[0].clientX;
+  });
+  tasksSection.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - touchStartX;
+    if (dx < -50) {
+      tasksSection.classList.add('show-calendar');
+    } else if (dx > 50) {
+      tasksSection.classList.remove('show-calendar');
+    }
+  });
+  let mouseStartX = 0;
+  tasksSection.addEventListener('mousedown', e => {
+    mouseStartX = e.clientX;
+  });
+  tasksSection.addEventListener('mouseup', e => {
+    const dx = e.clientX - mouseStartX;
+    if (dx < -50) {
+      tasksSection.classList.add('show-calendar');
+    } else if (dx > 50) {
+      tasksSection.classList.remove('show-calendar');
+    }
+  });
   if (calendarTitle) {
     calendarTitle.addEventListener('touchstart', e => {
       titleTouchX = e.touches[0].clientX;

--- a/styles.css
+++ b/styles.css
@@ -85,6 +85,34 @@ button {
 }
 button:hover { background: var(--button-hover-bg); }
 
+#add-task-btn {
+  background: linear-gradient(#87ceeb, #00008b);
+}
+#add-task-btn:hover {
+  background: linear-gradient(#87ceeb, #00008b);
+}
+
+#add-law-btn {
+  background: linear-gradient(#87ceeb, #4169e1);
+}
+#add-law-btn:hover {
+  background: linear-gradient(#87ceeb, #4169e1);
+}
+
+#add-mindset-btn {
+  background: linear-gradient(#800000, #ff0000);
+}
+#add-mindset-btn:hover {
+  background: linear-gradient(#800000, #ff0000);
+}
+
+.suggest-btn {
+  background: linear-gradient(#ffa726, #fb8c00);
+}
+.suggest-btn:hover {
+  background: linear-gradient(#ffa726, #fb8c00);
+}
+
 select {
   height: 40px;
   background: rgba(0, 0, 0, 0.8);
@@ -437,22 +465,22 @@ li:hover { transform: scale(1.02); }
 }
 #tasks-content,
 #calendar {
+  position: absolute;
+  top: 0;
   width: 100%;
   transition: transform 0.3s ease;
 }
 #calendar {
-  position: absolute;
-  top: 100%;
-  left: 0;
+  left: 100%;
   display: flex;
   flex-direction: column;
   height: 100%;
 }
 #tasks.show-calendar #tasks-content {
-  transform: translateY(-100%);
+  transform: translateX(-100%);
 }
 #tasks.show-calendar #calendar {
-  transform: translateY(-100%);
+  transform: translateX(-100%);
 }
 #calendar-title {
   height: 60px;
@@ -537,7 +565,7 @@ li:hover { transform: scale(1.02); }
   h2 { font-size: 14px; }
   p, span, label, input, button, li { font-size: 11px; }
   button { font-size: 10px; padding: 7px 14px; }
-  .icone-central { width: 105px; height: 105px; }
+  .icone-central { display: none; }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
   .menu-item img { width: 105px; height: 105px; }


### PR DESCRIPTION
## Summary
- Allow swiping between task list and 15-minute calendar on mobile.
- Style action buttons with new gradients and hide central icons on small screens.
- Add customizable color palette for aspects in the constitution menu.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/tasks.js && echo 'tasks ok'`
- `node --check js/main.js && echo 'main ok'`

------
https://chatgpt.com/codex/tasks/task_e_68a2a669e0cc8325ac54e2a5d9898a52