### PR TITLE
Adjust mobile menu icon offset and remove icon labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,12 +43,12 @@
     <div id="menu-carousel" class="menu-carousel"></div>
     <section id="menu" class="page active">
       <div class="menu-grid">
-        <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /></div>
-        <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /></div>
-        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /></div>
-        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /></div>
-        <div class="menu-item" data-page="options"><img src="constituicao.png" alt="Opções" /></div>
-        <div class="menu-item" data-page="history"><img src="historico.png" alt="Histórico" /></div>
+        <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="" /></div>
+        <div class="menu-item" data-page="laws"><img src="leis.png" alt="" /></div>
+        <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="" /></div>
+        <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="" /></div>
+        <div class="menu-item" data-page="options"><img src="constituicao.png" alt="" /></div>
+        <div class="menu-item" data-page="history"><img src="historico.png" alt="" /></div>
       </div>
     </section>
     <section id="tasks" class="page">

--- a/js/main.js
+++ b/js/main.js
@@ -287,12 +287,12 @@ document.querySelectorAll('.menu-item').forEach(item => {
 
 function initCarousel() {
   const items = [
-    { page: 'tasks', img: 'acoes.png', label: 'Tarefas' },
-    { page: 'laws', img: 'leis.png', label: 'Leis' },
-    { page: 'stats', img: 'estatisticas.png', label: 'Estatísticas' },
-    { page: 'mindset', img: 'mindset.png', label: 'Mindset' },
-    { page: 'options', img: 'constituicao.png', label: 'Opções' },
-    { page: 'history', img: 'historico.png', label: 'Histórico' }
+    { page: 'tasks', img: 'acoes.png' },
+    { page: 'laws', img: 'leis.png' },
+    { page: 'stats', img: 'estatisticas.png' },
+    { page: 'mindset', img: 'mindset.png' },
+    { page: 'options', img: 'constituicao.png' },
+    { page: 'history', img: 'historico.png' }
   ];
   let idx = 0;
   const img = document.createElement('img');
@@ -301,7 +301,6 @@ function initCarousel() {
   function render() {
     const item = items[idx];
     img.src = item.img;
-    img.alt = item.label;
     showPage(item.page);
   }
 

--- a/styles.css
+++ b/styles.css
@@ -569,7 +569,7 @@ li:hover { transform: scale(1.02); }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
   .menu-item img { width: 105px; height: 105px; }
-  .menu-carousel img { width: 105px; height: 105px; margin-top: 70px; }
+  .menu-carousel img { width: 105px; height: 105px; margin-top: 130px; }
   #main-header { height: 42px; }
   .header-container { padding: 7px 30px; }
   .header-logo { height: 28px; }


### PR DESCRIPTION
## Summary
- Remove text labels from main menu icons
- Drop unused label data in mobile carousel
- Lower mobile carousel icon by 60px for better positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b7ce39588325bdc5420ddf20f2f9