### PR TITLE
Fix mobile navigation to show page content

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -331,5 +331,8 @@ function showPage(pageId) {
   document.querySelectorAll('.page').forEach(sec => sec.classList.remove('active'));
   const section = document.getElementById(pageId);
   if (section) section.classList.add('active');
+  if (window.innerWidth <= 600) {
+    menuCarousel.style.display = pageId === 'menu' ? 'flex' : 'none';
+  }
 }
 


### PR DESCRIPTION
## Summary
- Ensure mobile menu carousel hides when navigating to other sections so page content displays correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a547f827f88325882f99fa58182cec